### PR TITLE
OS X v10.11(El Capitan)のAPI変更に対応した

### DIFF
--- a/Sources/HHKPS2USBDriver.cpp
+++ b/Sources/HHKPS2USBDriver.cpp
@@ -8,9 +8,9 @@
 #include "IOUSBLog.h"
 #include "HHKPS2USBDriver.h"
 
-#define super IOUSBHIDDriver
+#define super IOUSBHostHIDDevice
 
-OSDefineMetaClassAndStructors(HHKPS2USBDriver, IOUSBHIDDriver)
+OSDefineMetaClassAndStructors(HHKPS2USBDriver, IOUSBHostHIDDevice)
 
 
 #pragma mark ････････ IOHIDSystem Methods ･････････

--- a/Sources/HHKPS2USBDriver.cpp
+++ b/Sources/HHKPS2USBDriver.cpp
@@ -5,7 +5,7 @@
 	Copyright (C) 2005 NAKAHASHI Ichiro
 */
 
-#include <IOKit/usb/IOUSBLog.h>
+#include "IOUSBLog.h"
 #include "HHKPS2USBDriver.h"
 
 #define super IOUSBHIDDriver

--- a/Sources/HHKPS2USBDriver.h
+++ b/Sources/HHKPS2USBDriver.h
@@ -8,9 +8,9 @@
 #ifndef HHKPS2USBDRIVER_H
 #define HHKPS2USBDRIVER_H
 
-#include <IOKit/usb/IOUSBHIDDriver.h>
+#include <IOKit/usb/IOUSBHostHIDDevice.h>
 
-class HHKPS2USBDriver : public IOUSBHIDDriver
+class HHKPS2USBDriver : public IOUSBHostHIDDevice
 {
     OSDeclareDefaultStructors(HHKPS2USBDriver)
 

--- a/Sources/HHKPS2USBDriver.xcodeproj/project.pbxproj
+++ b/Sources/HHKPS2USBDriver.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		32D94FCF0562CBF700B6AF17 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		32D94FD00562CBF700B6AF17 /* HHKPS2USBDriver.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HHKPS2USBDriver.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		8DA8362C06AD9B9200E5AC22 /* Kernel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Kernel.framework; path = /System/Library/Frameworks/Kernel.framework; sourceTree = "<absolute>"; };
+		992C71D321CB578700434358 /* IOUSBLog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IOUSBLog.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,6 +61,7 @@
 		247142CAFF3F8F9811CA285C /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				992C71D321CB578700434358 /* IOUSBLog.h */,
 				1A224C3EFF42367911CA2CB7 /* HHKPS2USBDriver.h */,
 				1A224C3FFF42367911CA2CB7 /* HHKPS2USBDriver.cpp */,
 			);

--- a/Sources/IOUSBLog.h
+++ b/Sources/IOUSBLog.h
@@ -1,0 +1,30 @@
+//
+//  IOUSBLog.h
+//  HHKPS2USBDriver
+//
+//  Created by Kyohei Kadota on 2018/12/20.
+//
+
+#ifndef IOUSBLog_h
+#define IOUSBLog_h
+
+#include <IOKit/IOService.h>
+#include <IOKit/IOLib.h>
+
+#define DEBUG_LEVEL_PRODUCTION  0
+#define DEBUG_LEVEL_DEVELOPMENT 1
+#define DEBUG_LEVEL_ALPHA       2
+#define DEBUG_LEVEL_BETA        3
+#define DEBUG_LEVEL_FINAL       DEBUG_LEVEL_PRODUCTION
+
+#ifndef DEBUG_LEVEL
+#define DEBUG_LEVEL DEBUG_LEVEL_PRODUCTION
+#endif
+
+#if DEBUG_LEVEL != DEBUG_LEVEL_PRODUCTION
+#define USBLog(level, args...) KernelDebugLogInternal((level), 'USBF', ## args)
+#else
+#define USBLog(level, args...)
+#endif
+
+#endif /* IOUSBLog_h */

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -186,9 +186,9 @@
 		<key>com.apple.iokit.IOHIDFamily</key>
 		<string>2.0</string>
 		<key>com.apple.kpi.iokit</key>
-		<string>14.3</string>
+		<string>18.2</string>
 		<key>com.apple.kpi.libkern</key>
-		<string>14.3</string>
+		<string>18.2</string>
 	</dict>
 	<key>OSBundleRequired</key>
 	<string>Console</string>

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -33,7 +33,7 @@
 			<key>IOClass</key>
 			<string>HHKPS2USBDriver</string>
 			<key>IOProviderClass</key>
-			<string>IOUSBInterface</string>
+			<string>IOUSBHostInterface</string>
 			<key>bConfigurationValue</key>
 			<integer>1</integer>
 			<key>bInterfaceNumber</key>
@@ -52,7 +52,7 @@
 			<key>IOClass</key>
 			<string>HHKPS2USBDriver</string>
 			<key>IOProviderClass</key>
-			<string>IOUSBInterface</string>
+			<string>IOUSBHostInterface</string>
 			<key>bConfigurationValue</key>
 			<integer>1</integer>
 			<key>bInterfaceNumber</key>
@@ -71,7 +71,7 @@
 			<key>IOClass</key>
 			<string>HHKPS2USBDriver</string>
 			<key>IOProviderClass</key>
-			<string>IOUSBInterface</string>
+			<string>IOUSBHostInterface</string>
 			<key>bConfigurationValue</key>
 			<integer>1</integer>
 			<key>bInterfaceNumber</key>
@@ -90,7 +90,7 @@
 			<key>IOClass</key>
 			<string>HHKPS2USBDriver</string>
 			<key>IOProviderClass</key>
-			<string>IOUSBInterface</string>
+			<string>IOUSBHostInterface</string>
 			<key>bConfigurationValue</key>
 			<integer>1</integer>
 			<key>bInterfaceNumber</key>
@@ -109,7 +109,7 @@
 			<key>IOClass</key>
 			<string>HHKPS2USBDriver</string>
 			<key>IOProviderClass</key>
-			<string>IOUSBInterface</string>
+			<string>IOUSBHostInterface</string>
 			<key>bConfigurationValue</key>
 			<integer>1</integer>
 			<key>bInterfaceNumber</key>
@@ -128,7 +128,7 @@
 			<key>IOClass</key>
 			<string>HHKPS2USBDriver</string>
 			<key>IOProviderClass</key>
-			<string>IOUSBInterface</string>
+			<string>IOUSBHostInterface</string>
 			<key>bConfigurationValue</key>
 			<integer>1</integer>
 			<key>bInterfaceNumber</key>
@@ -147,7 +147,7 @@
 			<key>IOClass</key>
 			<string>HHKPS2USBDriver</string>
 			<key>IOProviderClass</key>
-			<string>IOUSBInterface</string>
+			<string>IOUSBHostInterface</string>
 			<key>bConfigurationValue</key>
 			<integer>1</integer>
 			<key>bInterfaceNumber</key>
@@ -166,7 +166,7 @@
 			<key>IOClass</key>
 			<string>HHKPS2USBDriver</string>
 			<key>IOProviderClass</key>
-			<string>IOUSBInterface</string>
+			<string>IOUSBHostInterface</string>
 			<key>bConfigurationValue</key>
 			<integer>1</integer>
 			<key>bInterfaceNumber</key>
@@ -181,10 +181,10 @@
 	<string>Copyright (C) 2005-2007 NAKAHASHI Ichiro</string>
 	<key>OSBundleLibraries</key>
 	<dict>
+		<key>com.apple.driver.usb.IOUSBHostHIDDevice</key>
+		<string>1.2</string>
 		<key>com.apple.iokit.IOHIDFamily</key>
 		<string>2.0</string>
-		<key>com.apple.iokit.IOUSBHIDDriver</key>
-		<string>705.4</string>
 		<key>com.apple.kpi.iokit</key>
 		<string>14.3</string>
 		<key>com.apple.kpi.libkern</key>

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.6</string>
+	<string>1.1.0</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>HHK via GASIA PS2 to USB Converter</key>


### PR DESCRIPTION
El Capitanより`IOUSBHIDDriver`などが削除され、`IOUSBHostHIDDevice`を使わなければならなくなったため修正した。

* [Kernel Changes for Objective-C
](https://developer.apple.com/library/archive/releasenotes/General/APIDiffsMacOSX10_11/Objective-C/Kernel.html)

`OSBundleLibraries`の値は、変更後にXcode 10.1でビルドしたkextから調べた。

```console
$ kextlibs -xml HHKPS2USBDriver
```